### PR TITLE
Setting page and time remaining update

### DIFF
--- a/YAPA/MainWindow.xaml.cs
+++ b/YAPA/MainWindow.xaml.cs
@@ -58,7 +58,7 @@ namespace YAPA
             WorkLabel = "work";
 
             dispacherTime.Tick += new EventHandler(DoTick);
-            dispacherTime.Interval = new TimeSpan(0, 0, 0, 1);
+            dispacherTime.Interval = new TimeSpan(0, 0, 0, 0, 250);
 
             // enable dragging
             this.MouseLeftButtonDown += MainWindow_MouseLeftButtonDown;

--- a/YAPA/PomodoroWeek.xaml.cs
+++ b/YAPA/PomodoroWeek.xaml.cs
@@ -33,7 +33,7 @@ namespace YAPA
             if (week.Count() < 7)
             {
                 var firstDay = week.Min(x => x.DateTime);
-                if (firstDay.DayOfWeek != DayOfWeek.Monday)
+                if (firstDay.DayOfWeek != DayOfWeek.Sunday)
                 {
                     for (int i = 0; i < 7 - week.Count(); i++)
                     {

--- a/YAPA/Settings.xaml
+++ b/YAPA/Settings.xaml
@@ -35,13 +35,13 @@
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,10,0,0" HorizontalAlignment="Center" Height="110" x:Name="DayPanel" Visibility="Collapsed">
                         <StackPanel Orientation="Vertical" Margin="0,5,0,0">
-                            <TextBlock Height="11" Width="13" Margin="0,-1,0,1" FontSize="10" VerticalAlignment="Top" Text="M"></TextBlock>
+                            <TextBlock Height="11" Width="13" Margin="0,0,0,1" ></TextBlock>
+                            <TextBlock Height="11" Width="13" Margin="0,0,0,1" FontSize="10" VerticalAlignment="Top" Text="M"></TextBlock>
                             <TextBlock Height="11" Width="13" Margin="0,0,0,1" ></TextBlock>
                             <TextBlock Height="11" Width="13" Margin="0,0,0,1" FontSize="10" VerticalAlignment="Top" Text="W"></TextBlock>
                             <TextBlock Height="11" Width="13" Margin="0,0,0,1" ></TextBlock>
                             <TextBlock Height="11" Width="13" Margin="0,0,0,1" FontSize="10" VerticalAlignment="Top" Text="F"></TextBlock>
                             <TextBlock Height="11" Width="13" Margin="0,0,0,1" ></TextBlock>
-                            <TextBlock Height="11" Width="13" Margin="0,0,0,1"></TextBlock>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal"  x:Name="WeekStackPanel" Width="377">
 

--- a/YAPA/Settings.xaml
+++ b/YAPA/Settings.xaml
@@ -15,6 +15,7 @@
         WindowStyle="None"
         WindowStartupLocation="CenterScreen"
         Background="Transparent"
+        Closing="SettingsWindow_Closing"
         AllowsTransparency="True">
     <Grid Background="Transparent">
         <Border Margin="10">
@@ -110,7 +111,7 @@
                 </StackPanel>
                 <Button x:Name="btnClose"
             		Command="{Binding SaveSettings}"
-            		Content="Save"
+            		Content="Done"
             		Cursor="Hand"
             		ToolTip="Save settings"
             		Margin="351,421,10,10" RenderTransformOrigin="0.478,0.513">

--- a/YAPA/ShowSettings.cs
+++ b/YAPA/ShowSettings.cs
@@ -37,8 +37,7 @@ namespace YAPA
         public void Execute(object parameter)
         {
             // show settings window
-            var settingsWindow = new Settings(_host, _host.ClockOpacity, _host.TextBrush, _host.WorkTime, _host.BreakTime, _host.BreakLongTime, _host.SoundEffects, _host.ShadowOpacity, _host.CountBackwards);
-            settingsWindow.ShowDialog();
+            Settings.CreateSettings(_host, _host.ClockOpacity, _host.TextBrush, _host.WorkTime, _host.BreakTime, _host.BreakLongTime, _host.SoundEffects, _host.ShadowOpacity, _host.CountBackwards);
         }
     }
 }

--- a/YAPA/YAPA.csproj
+++ b/YAPA/YAPA.csproj
@@ -164,24 +164,9 @@
     </Resource>
   </ItemGroup>
   <ItemGroup>
-    <Resource Include="Resources\backward.ico">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Resource>
     <Content Include="Resources\ding.wav">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Resource Include="Resources\pause.ico">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="Resources\preferences.ico">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="Resources\start.ico">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="Resources\stop.ico">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Resource>
     <Resource Include="Resources\loader.gif">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Resource>


### PR DESCRIPTION
This contains some misc fixes
- Change the Settings window so that you can only open one window at a time.
- In the settings window change the button text from 'save' to 'done'
- Fix the how the work history is displayed, it is currently broken for weeks that do not have all 7 days (start & end of the calendar and the new year)
- Change the frequency of how often we check if the timer time needs to be updated. This will change the average drift from been on average 500ms off to 125ms off. 
- fix the solution file to remove referenced to the previously deleted icons